### PR TITLE
Update `[png` information to mention it is format-agnostic

### DIFF
--- a/doc/texture_modifiers.adoc
+++ b/doc/texture_modifiers.adoc
@@ -350,11 +350,12 @@ These modifiers do not accept a base texture as they generate one from their arg
 
 ===== `[png:<data>`
 
-* `data` is a base64-encoded PNG bytestring
+* `data` is a base64-encoded image bytestring
 
-Creates a texture from an embedded base64-encoded PNG image.
+Creates a texture from an embedded base64-encoded image.
+Contrary to the texture modifier's name, it supports any image format that IrrlichtMt supports, not only PNG.
 
-`data` can be built by combining `minetest.encode_base64` and `minetest.encode_png`:
+For PNG images, `data` can be built by combining `minetest.encode_base64` and `minetest.encode_png`:
 
 [source,lua]
 ====


### PR DESCRIPTION
From discord on the Discord:

> they call it ^[png: but it can load any image format...

> I realised when reading the code that it just feeds the data as an in-memory file to irrlicht, so it supports any image formats irrlicht(mt) supports

>realistically it'd be useful for TGA in addition to PNG but... you could also cram a JPEG into there if you'd ever want that